### PR TITLE
Update regex

### DIFF
--- a/a2er.js
+++ b/a2er.js
@@ -1,4 +1,4 @@
-const reg = /([A-Za-z]*[AEIOUaeiou][a-z]*[^aeo\s])ar?([wtzpsdfghjklcvbnm]?)(\b)/gm;
+const reg = /([A-Za-z]*[AEIOUaeiou][a-z]*[^aeo\s])ar?([wtzpsdfghjklcvbnm]?)([^a-zäöüß])/gm;
 
 var isParsing = false;
 var enableReplacement = true;


### PR DESCRIPTION
* Remove \b as it doesn't see non-ASCII letters (like ä) as word characters; now "Innstraße" is not converted to "Innstrerße" any more
* CamelCase should now be detected, "JavaScript" is now converted to "JaverScript"